### PR TITLE
Fix: Deploy job virtual environment (v1.0.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        uv sync --extra dev
         uv pip install twine
 
     - name: Publish to PyPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.1 - Bugfix release
+
+* **Bugfix**: Fix deploy job in GitHub Actions workflow
+  - Create virtual environment before installing twine in deploy job
+  - Fixes error: "No virtual environment found" during PyPI deployment
+
 ## 1.0.0 - Migration to modern Python tooling
 
 * **Major change**: Complete migration to modern Python packaging and tooling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "OpenFisca-CEQ"
-version = "1.0.0"
+version = "1.0.1"
 description = "OpenFisca tax and benefit system for CEQ"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Bugfix Release 1.0.1

### Changes
- Fix deploy job in GitHub Actions workflow
- Create virtual environment before installing twine
- Resolves error: "No virtual environment found" during PyPI deployment

### Technical Details
- Added `uv sync --extra dev` step before `uv pip install twine` in deploy job
- Ensures virtual environment exists before using `uv pip` and `uv run`

### Version Bump
- Version bumped from 1.0.0 to 1.0.1 (bugfix release)
- CHANGELOG updated with release notes

### Testing
- Workflow changes tested in GitHub Actions
- Deploy job should now succeed on merge to master

Made with [Cursor](https://cursor.com)